### PR TITLE
t-SNE manifolds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ metadata/
 utils/__pycache__/unpickler.cpython-311.pyc
 BSE_BrainHack.code-workspace
 image.png
+.venv/ 

--- a/tsne_manifold.py
+++ b/tsne_manifold.py
@@ -50,7 +50,6 @@ def find_embeddings_file(animal, patient_id, window_length=60, stride_length=30,
     except Exception as e:
         raise RuntimeError(f"Failed to generate embeddings file: {str(e)}")
 
-# TODO: update for current params
 def get_param_suffix(tsne_params):
     """Generate filename suffix based on parameters."""
     return f"_Ncomps{tsne_params['n_components']}_LR{tsne_params['lr']}_PP{tsne_params['pp']}_RNG{tsne_params['rng']}"
@@ -76,11 +75,8 @@ def apply_tsne(embeddings, tsne_params):
     # Compute embeddings
     print(f"\nReducing to {tsne_params['n_components']} dimensions using t-SNE...")
     reduced_embeddings = tsne.fit_transform(embeddings)
-    feature_names = tsne.get_feature_names_out()
+    return reduced_embeddings
 
-    return reduced_embeddings, feature_names
-
-# TODO: PARAMS
 def process_single_patient(animal, patient_id, tsne_params, window_length=60, stride_length=30, 
                          data_type='train'):
     """Process embeddings for a single patient."""
@@ -104,7 +100,7 @@ def process_single_patient(animal, patient_id, tsne_params, window_length=60, st
     print(f"Reshaped embeddings: {embeddings_flat.shape}")
     
     # Apply tsne
-    reduced, labels = apply_tsne(embeddings_flat, tsne_params)
+    reduced = apply_tsne(embeddings_flat, tsne_params)
     
     print(f"t-SNE output shape: {reduced.shape}")
     print(f"t-SNE range - X: [{reduced[:, 0].min():.2f}, {reduced[:, 0].max():.2f}], "
@@ -112,28 +108,13 @@ def process_single_patient(animal, patient_id, tsne_params, window_length=60, st
 
     # Save visualization
     plt.figure(figsize=(12, 10))
-    # TODO: expand for more than 2D
-    # if tsne_params['n_components']==2:
-    # plt.scatter(reduced[:, 0], reduced[:, 1], cmap='Spectral', s=1)
-    # plt.colorbar(label='Cluster')
     colors = np.tile(np.arange(n_timepoints), n_files)
     plt.scatter(reduced[:, 0], reduced[:, 1], 
                 c=colors, cmap='viridis', s=1, alpha=0.5)
     plt.colorbar(label='Timepoint within window')
-    plt.title(f't-SNE Brain State Embeddings for Patient {patient_id}') #{patient_id}\nMN={mn_ratio}, FP={fp_ratio}, n={n_neighbors}')
+    plt.title(f't-SNE Brain State Embeddings for Patient {patient_id}')
     plt.xlabel('t-SNE Dimension 1')
     plt.ylabel('t-SNE Dimension 2')
-
-    # if do_10d:
-    #     plt.scatter(dim2_space[:, 0], dim2_space[:, 1], c=cluster_labels, cmap='Spectral', s=1)
-    #     plt.colorbar(label='Cluster')
-    # else:
-    #     # Create a color gradient based on time points within each file
-    #     colors = np.tile(np.arange(n_timepoints), n_files)
-    #     plt.scatter(dim2_space[:, 0], dim2_space[:, 1], 
-    #                c=colors, cmap='viridis', s=1, alpha=0.5)
-    #     plt.colorbar(label='Timepoint within window')
-    
     
     # Generate parameter suffix for filenames
     param_suffix = get_param_suffix(tsne_params)
@@ -143,64 +124,137 @@ def process_single_patient(animal, patient_id, tsne_params, window_length=60, st
     plt.savefig(plot_path, dpi=300, bbox_inches='tight')
     plt.close()
     
-    # TODO: update saving processed data
-    # # Save processed data
-    # output_data = {
-    #     'patient_id': patient_id,
-    #     'transformed_points_2d': dim2_space,
-    #     'transformed_points_10d': dim10_space if do_10d else None,
-    #     'cluster_labels': cluster_labels if do_10d else None,
-    #     'file_indices': np.repeat(np.arange(n_files), n_timepoints),
-    #     'window_indices': np.tile(np.arange(n_timepoints), n_files),
-    #     'start_times': np.repeat(data['start_times'], n_timepoints),
-    #     'stop_times': np.repeat(data['stop_times'], n_timepoints),
-    #     'original_shape': embeddings_data.shape,
-    #     'seizure_types': None,
-    #     'seizure_events': None,
-    #     'pacmap_params': {
-    #         'mn_ratio': mn_ratio,
-    #         'fp_ratio': fp_ratio,
-    #         'n_neighbors': n_neighbors,
-    #         'do_10d': do_10d,
-    #         'window_length': window_length,
-    #         'stride_length': stride_length,
-    #         'data_type': data_type
-    #     }
-    # }
+    # Save processed data
+    output_data = {
+        'patient_id': patient_id,
+        'transformed_points_2d': reduced,
+        'file_indices': np.repeat(np.arange(n_files), n_timepoints),
+        'window_indices': np.tile(np.arange(n_timepoints), n_files),
+        'start_times': np.repeat(data['start_times'], n_timepoints),
+        'stop_times': np.repeat(data['stop_times'], n_timepoints),
+        'original_shape': embeddings_data.shape,
+        'seizure_types': None,
+        'seizure_events': None,
+        'tsne_params': {
+            'n_components': tsne_params['n_components'],
+            'lr': tsne_params['lr'],
+            'rng': tsne_params['rng'],
+            'perplexity': tsne_params['pp'],
+            'window_length': window_length,
+            'stride_length': stride_length,
+            'data_type': data_type
+        }
+    }
     
-    # # Save processed data with parameters in filename
-    # output_path = os.path.join(output_dir, f'manifold_Epat{patient_id}{param_suffix}.pkl')
-    # with open(output_path, 'wb') as f:
-    #     pickle.dump(output_data, f)
+    # Save processed data with parameters in filename
+    output_path = os.path.join(output_dir, f'manifold_Epat{patient_id}{param_suffix}.pkl')
+    with open(output_path, 'wb') as f:
+        pickle.dump(output_data, f)
     
-    # print(f"\nProcessing complete. Files saved to {output_dir}")
-    # return output_path, plot_path
+    print(f"\nProcessing complete. Files saved to {output_dir}")
+    return output_path, plot_path
+
+def process_all_patients(animal, tsne_params, window_length=60, stride_length=30, data_type='train'):
+    """Process all patients with embeddings files."""
+    print("\n=== Processing All Patients ===\n")
+    output_dir = os.path.join('output', animal, "tSNE")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    embeddings_files = glob.glob(os.path.join('output', animal, 'Epat*', f'embeddings_Epat*_W{window_length}_S{stride_length}_{data_type}.pkl'))
+
+    print(f"\nFound {len(embeddings_files)} patients to process")
+    for embeddings_file in embeddings_files:
+        try:
+            match = re.search(r'Epat(\d+)', embeddings_file)
+            if not match:
+                continue
+            patient_num = int(match.group(1))
+
+            print(f"\n=== Processing Epat{patient_num} ===")
+            process_single_patient(animal, patient_num, tsne_params, window_length, stride_length, data_type)
+        except Exception as e:
+            print(f"Error processing patient {patient_num}: {e}")
+            continue
+
+def process_merged_patients(animal, patient_ids, tsne_params, window_length=60, stride_length=30, data_type='train'):
+    """Process and merge embeddings from multiple patients."""
+    print("\n=== Merging Patient Embeddings ===\n")
+    output_dir = os.path.join('output', animal, "tSNE", '_'.join([f"Epat{pid}" for pid in patient_ids]))
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    merged_data = []
+    for patient_id in patient_ids:
+        try:
+            print(f"\nLoading data for patient {patient_id}...")
+            embeddings_path = find_embeddings_file(animal, patient_id, window_length, stride_length, data_type)
+
+            with open(embeddings_path, 'rb') as f:
+                data = pickle.load(f)
+
+            embeddings = data['patient_embeddings']
+            n_files, n_timepoints, n_features = embeddings.shape
+            embeddings_flat = embeddings.reshape(-1, n_features)
+            merged_data.append(embeddings_flat)
+
+            print(f"Added {n_files * n_timepoints} points for patient {patient_id}")
+        except Exception as e:
+            print(f"Error loading data for patient {patient_id}: {e}")
+
+    merged_data = np.vstack(merged_data)
+    print(f"\nTotal merged embeddings shape: {merged_data.shape}")
+
+    reduced = apply_tsne(merged_data, tsne_params)
+
+    plt.figure(figsize=(12, 10))
+    colors = np.concatenate([np.full(embeddings.shape[0], i) for i, embeddings in enumerate(merged_data)])
+    plt.scatter(reduced[:, 0], reduced[:, 1], c=colors, cmap='tab10', s=1, alpha=0.5)
+    plt.colorbar(label='Patient ID')
+    plt.title(f't-SNE Brain State Embeddings for Merged Patients: {patient_ids}')
+    plt.xlabel('t-SNE Dimension 1')
+    plt.ylabel('t-SNE Dimension 2')
+
+    param_suffix = get_param_suffix(tsne_params)
+    plot_path = os.path.join(output_dir, f'pointcloud_merged_{param_suffix}.png')
+    plt.savefig(plot_path, dpi=300, bbox_inches='tight')
+    plt.close()
+
+    print(f"\nMerged processing complete. Files saved to {output_dir}")
 
 def main():
-    # Some settings for the tSNE based on arguments TODO
-    animal = 'jackal'
-    patient_id = '30'
-    window_length = 60
-    stride_length = 30
-    data_type = 'train'
+    parser = argparse.ArgumentParser(description='Process brain state embeddings using t-SNE.')
+    parser.add_argument('--animal', type=str, required=True, help='Animal name (e.g., rhesusmonkey)')
+    parser.add_argument('--patient_id', type=int, help='Patient ID (e.g., 37)')
+    parser.add_argument('--all', action='store_true', help='Process all patients')
+    parser.add_argument('--merge', type=int, nargs='+', help='List of patient IDs as integers (e.g., 37 38)')
+    parser.add_argument('--window_length', type=int, default=60, help='Window length in seconds (default: 60)')
+    parser.add_argument('--stride_length', type=int, default=30, help='Stride length in seconds (default: 30)')
+    parser.add_argument('--data_type', type=str, default='train', choices=['train', 'valfinetune', 'valunseen'], help='Data type to process (default: train)')
+    parser.add_argument('--n_components', type=int, default=2, help='Number of t-SNE dimensions (default: 2)')
+    parser.add_argument('--lr', type=float, default=200.0, help='Learning rate for t-SNE optimization (default: 200.0)')
+    parser.add_argument('--pp', type=float, default=30.0, help='Perplexity for t-SNE optimization (default: 30.0)')
+    parser.add_argument('--rng', type=int, default=42, help='Random seed for t-SNE (default: 42)')
 
-    tsne_params={
-        'n_components': 2,
-        'lr': 'auto',
-        'rng': 15,
-        'pp': 30,
+    args = parser.parse_args()
+
+    tsne_params = {
+        'n_components': args.n_components,
+        'lr': args.lr,
+        'pp': args.pp,
+        'rng': args.rng
     }
-    # Common parameters for all processing functions
-    common_params = {
-        'window_length': window_length, #args.window_length,
-        'stride_length': stride_length,#args.stride_length,
-        'data_type': data_type,#args.data_type
-    }
-    
-    # TODO: add process_all_patients and process_merged_patients
-    # process_single_patient(args.animal, args.patient_id, tsne_params)
-    try:
-        process_single_patient(animal, patient_id, tsne_params, **common_params)
+
+    try: 
+        if args.merge:
+            process_merged_patients(args.animal, args.merge, tsne_params, args.window_length, args.stride_length, args.data_type)
+        elif args.all:
+            process_all_patients(args.animal, tsne_params, args.window_length, args.stride_length, args.data_type)
+        elif args.patient_id:
+            process_single_patient(args.animal, args.patient_id, tsne_params, args.window_length, args.stride_length, args.data_type)
+        else:
+            print("Error: Please specify either --patient_id, --all, or --merge")
+            return
     except Exception as e:
         print(f"\nError: {e}")
         exit(1)

--- a/tsne_manifold.py
+++ b/tsne_manifold.py
@@ -1,0 +1,210 @@
+import numpy as np
+from sklearn.manifold import TSNE
+import pickle
+import hdbscan
+import os
+import matplotlib.pyplot as plt
+import argparse
+import pandas as pd
+from utils.unpickler_split import process_patient_files as unpack_single_patient
+import re
+import glob
+
+def setup_output_directory(animal, patient_id):
+    """Create output directory structure for the patient."""
+    output_dir = os.path.join('output', animal, "tSNE", f"Epat{patient_id}")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    return output_dir
+
+def find_embeddings_file(animal, patient_id, window_length=60, stride_length=30, data_type='train'):
+    """Find the embeddings file for a patient. If not found, generate it."""
+    # Convert integer to Epat format
+    patient_id_str = f"Epat{patient_id}"
+    
+    output_dir = os.path.join('output', animal, patient_id_str)
+    version_file = f'embeddings_{patient_id_str}_W{window_length}_S{stride_length}_{data_type}.pkl'
+    version_path = os.path.join(output_dir, version_file)
+    
+    if os.path.exists(version_path):
+        return version_path
+        
+    # If embeddings file doesn't exist, generate it using unpickler_split
+    print(f"\nEmbeddings file not found for patient {patient_id_str}. Generating it now...")
+    
+    try:
+        # Get all files for this patient
+        pattern = os.path.join('source_pickles', animal, 'Epoch*',
+                             f'{window_length}SecondWindow_{stride_length}SecondStride',
+                             data_type, f'{patient_id_str}_*.pkl')
+        patient_files = glob.glob(pattern)
+        
+        if not patient_files:
+            raise FileNotFoundError(f"No files found matching pattern: {pattern}")
+            
+        # Run unpickler to generate embeddings file
+        version_path = unpack_single_patient(patient_files, animal, patient_id_str, 
+                                           window_length, stride_length, data_type)
+        print(f"Successfully generated embeddings file at {version_path}")
+        return version_path
+    except Exception as e:
+        raise RuntimeError(f"Failed to generate embeddings file: {str(e)}")
+
+# TODO: update for current params
+def get_param_suffix(tsne_params):
+    """Generate filename suffix based on parameters."""
+    return f"_Ncomps{tsne_params['n_components']}_LR{tsne_params['lr']}_PP{tsne_params['pp']}_RNG{tsne_params['rng']}"
+
+def apply_tsne(embeddings, tsne_params):
+    """Apply t-SNE dimensionality reduction
+
+    Args:
+        embeddings: numpy array of shape (n_samples, n_features)
+        lr: learning rate - float or "auto". usually between [10.0, 1000.0]
+        pp: perplexity - related to number of nearest neighbors; must be less than n_samples; maybe between 5 and 50
+        rng: seed for random number generation
+        
+    Returns:
+        TODO
+    """
+    # Build tSNE object
+    tsne = TSNE(n_components=tsne_params['n_components'], 
+                learning_rate=tsne_params['lr'], 
+                perplexity=tsne_params['pp'],
+                random_state=tsne_params['rng'])
+
+    # Compute embeddings
+    print(f"\nReducing to {tsne_params['n_components']} dimensions using t-SNE...")
+    reduced_embeddings = tsne.fit_transform(embeddings)
+    feature_names = tsne.get_feature_names_out()
+
+    return reduced_embeddings, feature_names
+
+# TODO: PARAMS
+def process_single_patient(animal, patient_id, tsne_params, window_length=60, stride_length=30, 
+                         data_type='train'):
+    """Process embeddings for a single patient."""
+    print("\n=== Processing Brain State Embeddings ===\n")
+    output_dir = setup_output_directory(animal, patient_id)
+    
+    # Load embeddings data
+    print("\nLoading embeddings from unpickler output...")
+    embeddings_path = find_embeddings_file(animal, patient_id, window_length, 
+                                         stride_length, data_type)
+    with open(embeddings_path, 'rb') as f:
+        data = pickle.load(f)
+    
+    # Get the embeddings and reshape them
+    embeddings_data = data['patient_embeddings']
+    print(f"Original embeddings shape: {embeddings_data.shape}")  # (n_files, n_timepoints, n_features)
+    
+    # Reshape to (n_files*n_timepoints, n_features)
+    n_files, n_timepoints, n_features = embeddings_data.shape
+    embeddings_flat = embeddings_data.reshape(-1, n_features)  # Now (n_files*n_timepoints, n_features)
+    print(f"Reshaped embeddings: {embeddings_flat.shape}")
+    
+    # Apply tsne
+    reduced, labels = apply_tsne(embeddings_flat, tsne_params)
+    
+    print(f"t-SNE output shape: {reduced.shape}")
+    print(f"t-SNE range - X: [{reduced[:, 0].min():.2f}, {reduced[:, 0].max():.2f}], "
+          f"Y: [{reduced[:, 1].min():.2f}, {reduced[:, 1].max():.2f}]")
+
+    # Save visualization
+    plt.figure(figsize=(12, 10))
+    # TODO: expand for more than 2D
+    # if tsne_params['n_components']==2:
+    # plt.scatter(reduced[:, 0], reduced[:, 1], cmap='Spectral', s=1)
+    # plt.colorbar(label='Cluster')
+    colors = np.tile(np.arange(n_timepoints), n_files)
+    plt.scatter(reduced[:, 0], reduced[:, 1], 
+                c=colors, cmap='viridis', s=1, alpha=0.5)
+    plt.colorbar(label='Timepoint within window')
+    plt.title(f't-SNE Brain State Embeddings for Patient {patient_id}') #{patient_id}\nMN={mn_ratio}, FP={fp_ratio}, n={n_neighbors}')
+    plt.xlabel('t-SNE Dimension 1')
+    plt.ylabel('t-SNE Dimension 2')
+
+    # if do_10d:
+    #     plt.scatter(dim2_space[:, 0], dim2_space[:, 1], c=cluster_labels, cmap='Spectral', s=1)
+    #     plt.colorbar(label='Cluster')
+    # else:
+    #     # Create a color gradient based on time points within each file
+    #     colors = np.tile(np.arange(n_timepoints), n_files)
+    #     plt.scatter(dim2_space[:, 0], dim2_space[:, 1], 
+    #                c=colors, cmap='viridis', s=1, alpha=0.5)
+    #     plt.colorbar(label='Timepoint within window')
+    
+    
+    # Generate parameter suffix for filenames
+    param_suffix = get_param_suffix(tsne_params)
+    
+    # Save plot with parameters in filename
+    plot_path = os.path.join(output_dir, f'pointcloud_Epat{patient_id}{param_suffix}.png')
+    plt.savefig(plot_path, dpi=300, bbox_inches='tight')
+    plt.close()
+    
+    # TODO: update saving processed data
+    # # Save processed data
+    # output_data = {
+    #     'patient_id': patient_id,
+    #     'transformed_points_2d': dim2_space,
+    #     'transformed_points_10d': dim10_space if do_10d else None,
+    #     'cluster_labels': cluster_labels if do_10d else None,
+    #     'file_indices': np.repeat(np.arange(n_files), n_timepoints),
+    #     'window_indices': np.tile(np.arange(n_timepoints), n_files),
+    #     'start_times': np.repeat(data['start_times'], n_timepoints),
+    #     'stop_times': np.repeat(data['stop_times'], n_timepoints),
+    #     'original_shape': embeddings_data.shape,
+    #     'seizure_types': None,
+    #     'seizure_events': None,
+    #     'pacmap_params': {
+    #         'mn_ratio': mn_ratio,
+    #         'fp_ratio': fp_ratio,
+    #         'n_neighbors': n_neighbors,
+    #         'do_10d': do_10d,
+    #         'window_length': window_length,
+    #         'stride_length': stride_length,
+    #         'data_type': data_type
+    #     }
+    # }
+    
+    # # Save processed data with parameters in filename
+    # output_path = os.path.join(output_dir, f'manifold_Epat{patient_id}{param_suffix}.pkl')
+    # with open(output_path, 'wb') as f:
+    #     pickle.dump(output_data, f)
+    
+    # print(f"\nProcessing complete. Files saved to {output_dir}")
+    # return output_path, plot_path
+
+def main():
+    # Some settings for the tSNE based on arguments TODO
+    animal = 'jackal'
+    patient_id = '30'
+    window_length = 60
+    stride_length = 30
+    data_type = 'train'
+
+    tsne_params={
+        'n_components': 2,
+        'lr': 'auto',
+        'rng': 15,
+        'pp': 30,
+    }
+    # Common parameters for all processing functions
+    common_params = {
+        'window_length': window_length, #args.window_length,
+        'stride_length': stride_length,#args.stride_length,
+        'data_type': data_type,#args.data_type
+    }
+    
+    # TODO: add process_all_patients and process_merged_patients
+    # process_single_patient(args.animal, args.patient_id, tsne_params)
+    try:
+        process_single_patient(animal, patient_id, tsne_params, **common_params)
+    except Exception as e:
+        print(f"\nError: {e}")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tsne_sleep_tagger.py
+++ b/tsne_sleep_tagger.py
@@ -1,0 +1,279 @@
+import pickle
+import pandas as pd
+import numpy as np
+from datetime import datetime
+import matplotlib.pyplot as plt
+import os
+import argparse
+
+def get_merged_patient_dir(patient_nums):
+    """Create directory name for merged patients."""
+    if isinstance(patient_nums[0], str) and patient_nums[0].startswith('Epat'):
+        return "_".join(sorted(patient_nums))
+    else:
+        patient_ids = [f"Epat{num}" for num in sorted(patient_nums)]
+        return "_".join(patient_ids)
+
+def extract_params_from_filename(filename):
+    """Extract t-SNE parameters from filename."""
+    try:
+        parts = filename.split('_')
+        ncomps_part = next(part for part in parts if part.startswith('Ncomps'))
+        lr_part = next(part for part in parts if part.startswith('LR'))
+        pp_part = next(part for part in parts if part.startswith('PP'))
+        rng_part = next(part for part in parts if part.startswith('RNG')).split('.')[0]
+
+        n_components = int(ncomps_part[6:])
+        lr = float(lr_part[2:])
+        perplexity = float(pp_part[2:])
+        rng = int(rng_part[3:])
+
+        return f"_Ncomps{n_components}_LR{lr}_PP{perplexity}_RNG{rng}"
+    except Exception as e:
+        print(f"Warning: Parameter extraction failed: {str(e)}")
+        return None
+
+def setup_output_directory(manifold_path):
+    """Setup output directory based on manifold file path."""
+    if not os.path.exists(manifold_path):
+        raise FileNotFoundError(f"No manifold file found at {manifold_path}")
+
+    output_dir = os.path.dirname(manifold_path)
+    return output_dir, manifold_path
+
+def get_patient_ids_from_path(manifold_path):
+    """Extract patient IDs from manifold filename."""
+    filename = os.path.basename(manifold_path)
+    patient_section = filename.split('manifold_')[1].split('_Ncomps')[0]
+    patient_ids = patient_section.split('_')
+    return [int(pat_id.replace('Epat', '')) for pat_id in patient_ids]
+
+def load_sleep_metadata(excel_path):
+    """Load and process sleep metadata from Excel file."""
+    print("Loading sleep metadata...")
+    sleep_data = pd.read_excel(excel_path)
+    sleep_data['OnsetDatetime'] = pd.to_datetime(sleep_data['OnsetDatetime'])
+    sleep_data['OffsetDatetime'] = pd.to_datetime(sleep_data['OffsetDatetime'])
+    return sleep_data
+
+def find_sleep_stage(start_time, stop_time, sleep_data, patient_id, certainty_threshold):
+    """Find sleep stage for a given time window and patient."""
+    patient_sleep = sleep_data[
+        (sleep_data['PatID'] == patient_id) & 
+        (sleep_data['AvgCertainty'] >= certainty_threshold)
+    ]
+
+    if len(patient_sleep) == 0:
+        return 'unknown'
+
+    overlapping_stages = patient_sleep[
+        (patient_sleep['OnsetDatetime'] <= stop_time) & 
+        (patient_sleep['OffsetDatetime'] >= start_time)
+    ]
+
+    if len(overlapping_stages) > 0:
+        sleep_stage = overlapping_stages.iloc[0]['SleepCat']
+        return 'N' if sleep_stage in ['N2', 'N3'] else sleep_stage
+    return 'unknown'
+
+def create_visualization(points_2d, sleep_stages, patient_id, output_dir, filename):
+    """Create and save point cloud visualization."""
+    plt.figure(figsize=(15, 10))
+    ax = plt.gca()
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+
+    background_mask = np.array(sleep_stages) == 'unknown'
+    plt.scatter(points_2d[background_mask, 0], 
+               points_2d[background_mask, 1],
+               color='gray',
+               alpha=0.1,
+               s=10,
+               label='Unclassified')
+
+    sleep_colors = {
+        'W': '#1f77b4',
+        'N': '#d62728',
+        'R': '#ff7f0e'
+    }
+    sleep_labels = {
+        'W': 'Wake',
+        'N': 'NREM',
+        'R': 'REM'
+    }
+
+    for stage, color in sleep_colors.items():
+        mask = np.array(sleep_stages) == stage
+        if np.any(mask):
+            plt.scatter(points_2d[mask, 0], 
+                       points_2d[mask, 1],
+                       color=color,
+                       alpha=0.75,
+                       s=20,
+                       label=sleep_labels[stage])
+
+    plt.title(f't-SNE 2D Projection for Patient {patient_id}\nSleep Stages Highlighted')
+    plt.xlabel('t-SNE Dimension 1')
+    plt.ylabel('t-SNE Dimension 2')
+    plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left', borderaxespad=0., markerscale=2)
+    plt.tight_layout()
+
+    plot_path = os.path.join(output_dir, filename)
+    plt.savefig(plot_path, dpi=300, bbox_inches='tight')
+    plt.close()
+
+    return plot_path
+
+def tag_points(patient_id, sleep_data, certainty_threshold, manifold_path):
+    """Tag transformed points with sleep stage metadata."""
+    output_dir, _ = setup_output_directory(manifold_path)
+    param_suffix = extract_params_from_filename(os.path.basename(manifold_path))
+    if not param_suffix:
+        print("Warning: Could not extract parameters from manifold filename")
+        param_suffix = ""
+
+    print("\nLoading patient data...")
+    with open(manifold_path, 'rb') as f:
+        data = pickle.load(f)
+
+    print("\nProcessing patient data...")
+    sleep_stages = []
+
+    if isinstance(patient_id, list):
+        unique_patients = sorted(patient_id)
+    else:
+        unique_patients = [patient_id]
+    print(f"Found {len(unique_patients)} patients in data")
+
+    for pat_id in unique_patients:
+        print(f"\nTagging sleep stages for Epat{pat_id}")
+
+        if len(unique_patients) > 1:
+            pat_mask = np.array([f"Epat{pat_id}" == pid for pid in data['patient_id']])
+        else:
+            pat_mask = np.ones(len(data['start_times']), dtype=bool)
+
+        pat_sleep = sleep_data[
+            (sleep_data['PatID'] == f"Epat{pat_id}") & 
+            (sleep_data['AvgCertainty'] >= certainty_threshold)
+        ]
+
+        if len(pat_sleep) == 0:
+            print(f"No sleep events found for Epat{pat_id}")
+            pat_stages = ['unknown'] * sum(pat_mask)
+        else:
+            print(f"Found {len(pat_sleep)} sleep events")
+            pat_stages = []
+            for start, stop in zip(
+                np.array(data['start_times'])[pat_mask],
+                np.array(data['stop_times'])[pat_mask]
+            ):
+                stage = find_sleep_stage(start, stop, sleep_data, f"Epat{pat_id}", certainty_threshold)
+                pat_stages.append(stage)
+
+        sleep_stages.extend(pat_stages)
+
+    stage_counts = pd.Series(sleep_stages).value_counts()
+    print("\nSleep stage distribution:")
+    for stage, count in stage_counts.items():
+        print(f"{stage}: {count}")
+
+    tagged_data = {
+        'patient_id': [f"Epat{id}" for id in unique_patients] * (len(sleep_stages) // len(unique_patients)),
+        'transformed_points_2d': data['transformed_points_2d'],
+        'sleep_stages': sleep_stages,
+        'start_times': data['start_times'],
+        'stop_times': data['stop_times']
+    }
+
+    display_name = "_".join([f"Epat{num}" for num in unique_patients])
+    tagged_data_path = os.path.join(output_dir, 
+        f'tagged_manifold_{display_name}{param_suffix}.pkl')
+
+    with open(tagged_data_path, 'wb') as f:
+        pickle.dump(tagged_data, f)
+
+    plot_path = create_visualization(
+        data['transformed_points_2d'],
+        sleep_stages,
+        display_name,
+        output_dir,
+        f'tagged_pointcloud_{display_name}{param_suffix}.png'
+    )
+
+    return tagged_data_path, plot_path
+
+def process_patient(manifold_path, sleep_data, certainty_threshold, force_reprocess=False):
+    """Process a single patient's or merged patients' data."""
+    patient_ids = get_patient_ids_from_path(manifold_path)
+
+    if len(patient_ids) > 1:
+        patient_ids_str = [f"Epat{num}" for num in patient_ids]
+        patient_sleep = sleep_data[sleep_data['PatID'].isin(patient_ids_str)]
+        if len(patient_sleep) == 0:
+            print(f"No sleep events found for any patients in {patient_ids_str}")
+            return
+        print(f"\nFound {len(patient_sleep)} total sleep events for merged patients")
+    else:
+        patient_id_str = f"Epat{patient_ids[0]}"
+        patient_sleep = sleep_data[sleep_data['PatID'] == patient_id_str]
+        if len(patient_sleep) == 0:
+            print(f"No sleep events found for patient {patient_id_str}")
+            return
+        print(f"\nFound {len(patient_sleep)} sleep events for {patient_id_str}")
+
+    output_dir, _ = setup_output_directory(manifold_path)
+    param_suffix = extract_params_from_filename(os.path.basename(manifold_path))
+    if not param_suffix:
+        print("Warning: Could not extract parameters from manifold filename")
+        param_suffix = ""
+
+    base_name = os.path.basename(manifold_path)
+    tagged_data_path = os.path.join(output_dir, f'tagged_{base_name}')
+
+    if os.path.exists(tagged_data_path) and not force_reprocess:
+        print(f"Found existing tagged data at {tagged_data_path}")
+        with open(tagged_data_path, 'rb') as f:
+            data = pickle.load(f)
+
+        if 'sleep_stages' not in data:
+            print("Found data in old format. Reprocessing...")
+            tagged_data_path, plot_path = tag_points(patient_ids, sleep_data, certainty_threshold, manifold_path)
+        else:
+            display_name = "_".join([f"Epat{num}" for num in patient_ids])
+            plot_path = create_visualization(
+                data['transformed_points_2d'],
+                data['sleep_stages'],
+                display_name,
+                output_dir,
+                f'tagged_pointcloud_{display_name}{param_suffix}.png'
+            )
+    else:
+        print(f"Running tagging process...")
+        tagged_data_path, plot_path = tag_points(patient_ids, sleep_data, certainty_threshold, manifold_path)
+
+    print(f"Processing complete! Files saved to {output_dir}")
+
+def main():
+    parser = argparse.ArgumentParser(description='Tag t-SNE embeddings with sleep stage metadata.')
+    parser.add_argument('--path', type=str, required=True,
+                      help='Path to manifold pickle file')
+    parser.add_argument('--metadata', type=str, 
+                      default='metadata/cleaned_sleep.xlsx',
+                      help='Path to Excel file containing sleep metadata')
+    parser.add_argument('--force', action='store_true',
+                      help='Force reprocessing of existing tagged data')
+    parser.add_argument('--certainty', type=float, default=0.6,
+                      help='Minimum certainty threshold for including sleep stages')
+
+    args = parser.parse_args()
+
+    try:
+        sleep_data = load_sleep_metadata(args.metadata)
+        process_patient(args.path, sleep_data, args.certainty, args.force)
+    except Exception as e:
+        print(f"\nError: {e}")
+        exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This code enables the creation of t-SNE manifolds + sleep state tagged point clouds to compare to the PaCMAP embeddings. Key hyperparameters are learning rate (lr) and perplexity (pp). Larger settings of perplexity increase consideration of global features, while lower values consider more local aspects.  

Similar to the pipeline for PaCMAP, first run the script tsne_manifold.py, e.g.: 

`python tsne_manifold.py --animal jackal --pp 50 --all` 

Results can be found in output/tSNE/. 

To create the tagged point clouds, select a manifold of interest and run tsne_sleep_tagger.py with the appropriate relative path, e.g.:

`python tsne_sleep_tagger.py --path output/jackal/tSNE/Epat28/manifold_Epat28_Ncomps2_LR200.0_PP5.0_RNG42.pkl`